### PR TITLE
Fix `npm run start`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "clean": "npx del-cli app/*",
-    "start": "webpack-dev-server",
+    "start": "webpack server",
     "build": "npm run clean && cross-env NODE_ENV=production npx webpack-cli",
     "build:dev": "npm run clean && cross-env NODE_ENV=development npx webpack-cli"
   },


### PR DESCRIPTION
For some reason the webpack team changed the command to webpack server (serve works too). I changed package.json and it works again!
`"start": "webpack server"`